### PR TITLE
Bugfix for P4V version detection

### DIFF
--- a/loginhook/ExtUtils.lua
+++ b/loginhook/ExtUtils.lua
@@ -269,10 +269,11 @@ function ExtUtils.isOlderP4V()
   -- info: clientversion: v87
   --
   local clientprog = Helix.Core.Server.GetVar( "clientprog" )
-  if string.find( clientprog, "P4V" ) then
-    -- strip the leading 'v' and check P4V's client version number
+  -- Check against P4V/ string because P4VS could match too
+  if string.find( clientprog, "P4V/" ) then
+    -- strip the leading 'v' and trailing potential brokered string then check P4V's client version number
     local clientversion = Helix.Core.Server.GetVar( "clientversion" )
-    local version = tonumber( string.sub( clientversion, 2 ) )
+    local version = tonumber( string.match( clientversion, "%d+" ) )
     if version < 86 then
       return true
     end


### PR DESCRIPTION
First change is to differentiate P4VS from P4V.
Previous code would catch p4vs as p4v
Instead of checking if P4VS is present in the string, we can use 'P4V/' as a string to look for.

Second change is to make the function compatible with brokers.
Previously it would cut the leading 'v' but don't touch the trailing substring appended to the version number. Trying to move that to a number would fail and make a runtime error.
Solution here is to simply extract the number from the string