### PR TITLE
Feature: allow client-sso-user to switch to sso-users only when using P4V

### DIFF
--- a/loginhook/ExtUtils.lua
+++ b/loginhook/ExtUtils.lua
@@ -208,6 +208,11 @@ function ExtUtils.verifyHost()
   return verify_host == "true"
 end
 
+function ExtUtils.allowUserClientP4V()
+  local allow_user_client_p4v = ExtUtils.iCfgData[ "allow-user-client-p4v" ]
+  return allow_user_client_p4v == "true"
+end
+
 function ExtUtils.isClientUser( user )
   -- users in the client-sso-users list are required to use P4LOGINSSO
   local required = ExtUtils.iCfgData[ "client-sso-users" ]

--- a/loginhook/ExtUtils.lua
+++ b/loginhook/ExtUtils.lua
@@ -209,7 +209,7 @@ function ExtUtils.verifyHost()
 end
 
 function ExtUtils.allowUserClientP4V()
-  local allow_user_client_p4v = ExtUtils.iCfgData[ "allow-user-client-p4v" ]
+  local allow_user_client_p4v = ExtUtils.iCfgData[ "allow-user-client-p4v-to-sso" ]
   return allow_user_client_p4v == "true"
 end
 

--- a/loginhook/main.lua
+++ b/loginhook/main.lua
@@ -41,7 +41,7 @@ function InstanceConfigFields()
     [ "user-identifier" ] = "... Trigger variable used as unique user identifier.",
     [ "name-identifier" ] = "... Field within IdP response containing unique user identifier.",
     [ "enable-logging" ] = "... Extension will write debug messages to a log if 'true'.",
-    [ "allow-user-client-p4v" ] = "... Extension will allow validation of JWT with user identifier."
+    [ "allow-user-client-p4v" ] = "... Extension will allow P4V falling back to use SSO rather than using P4LOGINSSO."
   }
 end
 
@@ -261,9 +261,9 @@ function AuthPreSSO()
   end
   if hasClientUsers and isClientUser then
     local currentClientProg = Helix.Core.Server.GetVar( "clientprog" )
-    if currentClientProg:match( "^Helix P4V" ) ~= nil then
+    if utils.allowUserClientP4V() and currentClientProg:match( "^Helix P4V" ) ~= nil then
       utils.debug( {
-        [ "AuthPreSSO" ] = "jump to ForceInteractiveSSO",
+        [ "AuthPreSSO" ] = "info: P4V detected, will fallback to SSO",
         [ "user" ] = user
       } )
       return webFlow()

--- a/loginhook/main.lua
+++ b/loginhook/main.lua
@@ -41,7 +41,7 @@ function InstanceConfigFields()
     [ "user-identifier" ] = "... Trigger variable used as unique user identifier.",
     [ "name-identifier" ] = "... Field within IdP response containing unique user identifier.",
     [ "enable-logging" ] = "... Extension will write debug messages to a log if 'true'.",
-    [ "allow-user-client-p4v" ] = "... Extension will allow P4V falling back to use SSO rather than using P4LOGINSSO."
+    [ "allow-user-client-p4v-to-sso" ] = "... Extension will fall back to SSO for P4V client rather than P4LOGINSSO if 'true'."
   }
 end
 


### PR DESCRIPTION
Hello,

This is a MR request that allows switching a user from the client-sso-users group (non-interactive flow) to the sso-users group (interactive flow) when using P4V (which is intended for interactive use).

Due to our synchronization requirements, we cannot solely use the interactive flow (sso-users) for our user accounts. Over the weekend, we sync data using libraries through [WAM](https://learn.microsoft.com/en-us/entra/msal/dotnet/acquiring-tokens/desktop-mobile/wam) to log in silently to Perforce, ensuring everything is ready for work on Monday morning. We aim to avoid any Web SSO authentication pop-ups that could disrupt this process.

The problem arises when a user is classified as a client-sso-user and attempts to log in using P4V. P4V prompts for the user’s password and does not execute the P4LOGINSSO routine. Therefore, the P4V app should automatically be considered as part of the interactive flow (Web SSO) since automation is not feasible in this context.